### PR TITLE
feat: acréscimo de uma escala pra imagem gerada

### DIFF
--- a/ios/Classes/extensions/URLPdf+Conversions.swift
+++ b/ios/Classes/extensions/URLPdf+Conversions.swift
@@ -30,8 +30,9 @@ extension URL {
             return nil
         }
         let pageRect = pdfPage!.getBoxRect(.mediaBox)
-
-        let renderer = UIGraphicsImageRenderer(size: CGSize(width: pageRect.size.width * scale, height: pageRect.size.height * scale))
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: pageRect.size.width * scale, height: pageRect.size.height * scale), format:format)
         let img = renderer.jpegData(withCompressionQuality: 1.0 ,actions: { cnv in
             cnv.cgContext.saveGState()
             UIColor.white.set()


### PR DESCRIPTION
📋 Descrição:

Implementação do fator de escala, pra imagens geradas. Visto que, a depender do tamanho da imagem, ele a gera em 2x e até 3x. 

📝 Plano de teste:

Confirmar que no iPhone 6, o app não quebra ao ler pdf.