### PR TITLE
update gradle dependencies to new repo

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ android {
 
 dependencies {
     implementation 'com.google.mlkit:barcode-scanning:17.3.0'
-    implementation 'com.github.barteksc:android-pdf-viewer:2.8.2'
+    implementation 'com.github.DImuthuUpe:AndroidPdfViewer:3.1.0-beta.1'
 }


### PR DESCRIPTION
* This change addresses the issue where the original dependency could not be resolved due to a 401 Unauthorized error. The new repository is a continuation of the original library as the owner has changed their GitHub username.